### PR TITLE
Handle previously logged in users

### DIFF
--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -35,7 +35,7 @@
       </mat-drawer>
       <mat-drawer-content>
         <div *ngIf="!isLoggedIn">
-          <app-login [logout]="doLogout" (loginEvent)="loginUser($event)"></app-login>
+          <app-login></app-login>
         </div>
         <router-outlet id="main-router-outlet" (activate)="mainRouterActive()"></router-outlet>
       </mat-drawer-content>

--- a/frontend/src/app/layout/layout.component.ts
+++ b/frontend/src/app/layout/layout.component.ts
@@ -1,41 +1,57 @@
-import { ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, NgZone, OnInit, ViewChild } from '@angular/core';
 import { Router, NavigationExtras, ActivatedRoute } from '@angular/router';
 import { MatDrawer } from '@angular/material/sidenav';
+import { AngularFireAuth } from '@angular/fire/auth';
 
 @Component({
   selector: 'app-layout',
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.css']
 })
-export class LayoutComponent implements OnInit {
+export class LayoutComponent implements OnInit, AfterViewInit{
 
   @ViewChild("drawer") drawer: MatDrawer;
 
   public username: string = "";
-  public isLoggedIn: boolean = false;
-  public doLogout: boolean = false;
+  public isLoggedIn: boolean = true;
+  private changedLogin = false;
 
-  constructor(private router: Router, private route: ActivatedRoute) { 
+  constructor(private router: Router, private route: ActivatedRoute, 
+    private auth: AngularFireAuth, private zone: NgZone) { 
     
+  }
+  ngAfterViewInit(): void {
+    setTimeout(() => { // Do nothing for 1.2 seconds and wait for auth service to detect login
+      if (!this.changedLogin) {
+        this.isLoggedIn = false;
+      }
+    }, 1200);
   }
 
   ngOnInit(): void {
-    console.log("route children:");
-    console.log(this.router);
-  }
-
-  loginUser(userData: {id: string, username: string}) {
-    console.log("User logged in: " + userData.id);
-    this.username = userData.username;
-    this.isLoggedIn = true;
-    console.log("IsLoggedIn changed to true");
-    this.router.navigate(['home'], {queryParams: {username: userData.username, id: userData.id}, relativeTo: this.route});   
+    this.zone.runOutsideAngular(() => this.auth.onAuthStateChanged((user) => {
+      if (user !== null) {
+        let username = user.displayName || user.email;
+        this.changedLogin = true;
+        this.zone.run(() => {
+          this.username = username;
+          this.isLoggedIn = true;
+        });
+        setTimeout(() => { // Do nothing and wait for login component to update
+        }, 1000);
+        this.zone.run(() => {
+          this.router.navigate(['home'], {queryParams: {username: this.username, id: user.uid}, relativeTo: this.route});   
+        })
+      } else {
+        this.username = "";
+      }
+    }));
   }
 
   logout() {
-    this.router.navigate(['/game']);
-    this.doLogout = true;
+    this.auth.signOut();
     this.isLoggedIn = false;
+    this.router.navigate(['/game']);
     console.log("IsLoggedIn changed to false");
   }
   

--- a/frontend/src/app/layout/login/login.component.ts
+++ b/frontend/src/app/layout/login/login.component.ts
@@ -17,33 +17,8 @@ export class LoginComponent {
   public passwordInput: string;
   public errorMessageText: string;
  
-  @Input()
-  public get logout(): boolean {
-    return this._logout;
-  }
-  public set logout(value: boolean) {
-    console.log("Login component: logout value changed to " + value);
-    this._logout = value;
-    if (this._logout === true) {
-      this.callSignOut();
-    }
-  }
-
-  @Output() loginEvent = new EventEmitter<{id: string, username: string}>(true);
-
   constructor(public auth: AngularFireAuth) {
-    // this.auth.onAuthStateChanged((user) => {
-    //   if (user !== null) {
-    //     this.userName = user.displayName || user.email;
-    //      // This gets called on logout for some reason... 
-    //      // Guess Firebase is passing in a usser object when it should be null...
-    //     //this.loginEvent.emit({id: user.uid, username: this.userName});
-    //     //this._showSignIn = false;
-    //   } else {
-    //     this.userName = null;
-    //     //this._showSignIn = true;
-    //   }
-    // });
+
   }
 
   toggleSignUp() {
@@ -59,7 +34,8 @@ export class LoginComponent {
   loginWithGoogle() {
     this.auth.signInWithPopup(new firebase.auth.GoogleAuthProvider())
       .then((user) => {
-        this.loginEvent.emit({id: user.user.uid, username: user.user.displayName});
+        // Signed in
+        this.clearErrorMessage();
       })
       .catch((error) => {
         var errorMessage = error.message;
@@ -70,36 +46,29 @@ export class LoginComponent {
   loginWithEmail() {
     this.auth.signInWithEmailAndPassword(this.emailInput, this.passwordInput)
       .then((user) => {
-        // Signed in 
-        // ...
+        // Signed in
         this.clearErrorMessage();
-        this.loginEvent.emit({id: user.user.uid, username: user.user.email})
+        this.toggleSignInForm();
       })
       .catch((error) => {
         var errorCode = error.code;
         var errorMessage = error.message;
         this.showErrorMessage(errorMessage);
-        this.toggleSignInForm();
       });
-      this.showSignInForm = false;
   }
 
   signUpWithEmail() {
     this.auth.createUserWithEmailAndPassword(this.emailInput, this.passwordInput)
       .then((user) => {
-        // Signed in 
-        // ...
+        // Signed in
+        this.toggleSignUp();
         this.clearErrorMessage();
-        this.loginEvent.emit({id: user.user.uid, username: user.user.email})
       })
       .catch((error) => {
         var errorCode = error.code;
         var errorMessage = error.message;
         this.showErrorMessage(errorMessage);
-        this.toggleSignUp();
       });
-
-      this.toggleSignUp();
   }
   
   callSignOut() {


### PR DESCRIPTION
Watch for users already being logged in using AngularFireAuth service inside of layout.component. Handle logouts in layout.component.ts. Remove now-unneeded inputs and outputs from login.component. Use a 1.2 sec timout before displaying the login component to wait for the AngularFireAuth service to detect a prior login and avoid updating the view twice. ngZone helps with updating the view once AngularFireAuth service detects a relogged in user.